### PR TITLE
ferment: un-fix modal headers and footers

### DIFF
--- a/ferment/js/components/RecipeModal.js
+++ b/ferment/js/components/RecipeModal.js
@@ -271,10 +271,7 @@ const RecipeModalComponent = {
       <div class="absolute inset-0 bg-black/50 modal-backdrop" @click="close"></div>
 
       <!-- Modal Container: full-screen on mobile, centered on desktop -->
-      <div class="relative w-full h-full sm:h-auto sm:max-w-3xl sm:mx-4 sm:max-h-[90vh] bg-bg-card dark:bg-dark-card sm:rounded-2xl border border-bg-secondary dark:border-dark-secondary flex flex-col overflow-hidden z-10" @click.stop>
-
-        <!-- Scrollable content wrapper (hero + tabs content all scroll together) -->
-        <div class="flex-1 overflow-y-auto custom-scrollbar">
+      <div class="relative w-full h-full sm:h-auto sm:max-w-3xl sm:mx-4 sm:max-h-[90vh] bg-bg-card dark:bg-dark-card sm:rounded-2xl border border-bg-secondary dark:border-dark-secondary overflow-y-auto custom-scrollbar z-10" @click.stop>
 
         <!-- Hero Section with gradient background -->
         <div :class="['relative bg-gradient-to-br text-white overflow-hidden', categoryGradient]">
@@ -361,7 +358,7 @@ const RecipeModalComponent = {
         </div>
 
         <!-- Tab Navigation -->
-        <div class="flex border-b border-bg-secondary dark:border-dark-secondary px-2 overflow-x-auto scrollbar-hide sticky top-0 bg-bg-card/95 dark:bg-dark-card/95 backdrop-blur-sm z-10">
+        <div class="flex border-b border-bg-secondary dark:border-dark-secondary px-2 overflow-x-auto scrollbar-hide">
           <button
             v-for="tab in tabs"
             :key="tab.id"
@@ -773,10 +770,8 @@ const RecipeModalComponent = {
 
         </div>
 
-        </div><!-- end scrollable wrapper -->
-
         <!-- Bottom Action Bar -->
-        <div class="flex-shrink-0 p-4 bg-bg-card/95 dark:bg-dark-card/95 backdrop-blur-sm border-t border-bg-secondary dark:border-dark-secondary">
+        <div class="p-4">
           <button
             @click="$emit('start-batch', recipe)"
             class="w-full py-3 bg-accent-culture hover:bg-accent-culture/90 text-white rounded-xl font-medium transition-colors flex items-center justify-center gap-2"

--- a/ferment/js/components/ToolsView.js
+++ b/ferment/js/components/ToolsView.js
@@ -597,9 +597,9 @@ const SettingsModalComponent = {
 
   template: `
     <div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm" @click="handleBackdropClick">
-      <div class="bg-bg-card dark:bg-dark-card rounded-2xl shadow-warm-xl w-full max-w-lg max-h-[85vh] overflow-hidden flex flex-col" @click.stop>
+      <div class="bg-bg-card dark:bg-dark-card rounded-2xl shadow-warm-xl w-full max-w-lg max-h-[85vh] overflow-y-auto custom-scrollbar" @click.stop>
         <!-- Header -->
-        <div class="flex items-center justify-between px-6 py-4 border-b border-bg-secondary dark:border-dark-secondary flex-shrink-0">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-bg-secondary dark:border-dark-secondary">
           <div class="flex items-center gap-2">
             <svg class="w-5 h-5 text-accent-brine" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
@@ -613,7 +613,7 @@ const SettingsModalComponent = {
         </div>
 
         <!-- Content -->
-        <div class="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+        <div class="px-6 py-5 space-y-6">
           <!-- Region -->
           <div>
             <label class="block text-sm font-medium text-text-secondary dark:text-dark-text-secondary mb-2">Region</label>


### PR DESCRIPTION
Remove sticky/fixed positioning from modal headers, tab nav, and footer action bars. All modal content now scrolls naturally as a single unit instead of having pinned sections.

- RecipeModal: remove flex-col split, sticky tab nav, fixed bottom bar
- SettingsModal: remove flex-col split with fixed header

https://claude.ai/code/session_01FCZCF3Yt4SpMUicYXcaNcN